### PR TITLE
Remove tls_disable from cluster listener

### DIFF
--- a/website/content/docs/configuration/controller.mdx
+++ b/website/content/docs/configuration/controller.mdx
@@ -158,8 +158,6 @@ listener "tcp" {
   address = "10.0.0.1"
   # The purpose of this listener
   purpose = "cluster"
-
-  tls_disable = false
 }
 
 # Root KMS configuration block: this is the root key for Boundary


### PR DESCRIPTION
Per https://www.boundaryproject.io/docs/configuration/listener/tcp#tls - having this here is invalid.
All tls parameters are valid only for the api listener. cluster and proxy connections use their own ephemeral TLS stacks